### PR TITLE
Add Dockerfile for Golang.

### DIFF
--- a/buildpack_go/Dockerfile
+++ b/buildpack_go/Dockerfile
@@ -1,0 +1,13 @@
+FROM quay.io/actcat/buildpack_base:latest
+
+MAINTAINER pocke <p.ck.t22@gmail.com>
+
+ENV GO_VERSION 1.5.2
+
+# Install go from binary distributions. https://golang.org/dl/
+RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz \
+  | tar -C /usr/local -xz
+
+ENV GOROOT /usr/local/go
+ENV GOPATH /root/go
+ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin


### PR DESCRIPTION
Connects to actcat/sideci_backend#91
- [x] Go 1.5.2 のインストール
- [x] GOPATH の設定(github等に存在するGoのパッケージがインストールされる先)
- [x] PATH を通す

@vexus2 レビューお願いします :bow:
