### PR TITLE
gitの賢いdiffを使う

### DIFF
--- a/buildpack_base/Dockerfile
+++ b/buildpack_base/Dockerfile
@@ -62,3 +62,6 @@ ENV PATH $PATH:/root/work/hub-linux-amd64-2.2.3/bin
 RUN echo 'alias git=hub' >> ~/.bashrc
 RUN mkdir /root/.config
 ADD hub /root/.config/hub
+
+# Set Git config
+RUN git config --global diff.compactionHeuristic true


### PR DESCRIPTION
gitが2.9からdiffが賢くなったので、それを利用することでmethod_definition_validatorの誤検知を減らしたい
ただ、現時点（2.9.3）では、設定を有効化しないと新しいdiffにならないので、baseイメージの段階で有効化する

検証結果:

```
# git diff
diff --git a/test.rb b/test.rb
index 1d47a34..3c76dd4 100644
--- a/test.rb
+++ b/test.rb
@@ -1,6 +1,10 @@
def finalize(values)

  values.each do |v|
+    v.prepare
+  end
+
+  values.each do |v|
    v.finalize
  end
end
# git config --global diff.compactionHeuristic true
# git diff
diff --git a/test.rb b/test.rb
index 1d47a34..3c76dd4 100644
--- a/test.rb
+++ b/test.rb
@@ -1,5 +1,9 @@
def finalize(values)

+  values.each do |v|
+    v.prepare
+  end
+
  values.each do |v|
    v.finalize
  end
```
