### PR TITLE
Install patchutils for filterdiff command

### DIFF
--- a/buildpack_base/Dockerfile
+++ b/buildpack_base/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && apt-get install -y \
     zlib1g-dev \
     python-software-properties \
     software-properties-common \
+    patchutils \
   && rm -rf /var/lib/apt/lists/*
 
 # Install git from launchpad maintain repo


### PR DESCRIPTION
https://linux.die.net/man/1/filterdiff

The command is necessary in all (Auto correct supported) container. So, I've added the command to base container.
