### PR TITLE
Install `glide` to manage golang vendoring

### DIFF
--- a/buildpack_go/Dockerfile
+++ b/buildpack_go/Dockerfile
@@ -8,6 +8,11 @@ ENV GO_VERSION 1.7
 RUN curl -sSL https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.tar.gz \
   | tar -C /usr/local -xz
 
+
+RUN sudo add-apt-repository ppa:masterminds/glide \
+  && sudo apt-get update \
+  && sudo apt-get install glide
+
 ENV GOROOT /usr/local/go
 ENV GOPATH /root/go
 ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin


### PR DESCRIPTION
See the document. https://github.com/Masterminds/glide#install