### PR TITLE
Update swift to 3.1.1, and use UTF-8 as locale

### DIFF
--- a/buildpack_swift/Dockerfile
+++ b/buildpack_swift/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/sourcekit:302
+FROM norionomura/sourcekit:311
 MAINTAINER Masataka Kuwabara <masataka.kuwabara@actcat.co.jp>
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -50,3 +50,10 @@ RUN apt-get update -y \
   && apt-get purge -y --auto-remove bison ruby \
   && make install \
   && rm -r /usr/src/ruby
+
+RUN apt-get update -y && \
+    apt-get install -y language-pack-en && \
+    update-locale en_US.UTF-8
+
+ENV LC_ALL="en_US.UTF-8" \
+    LANG="en_US.UTF-8"


### PR DESCRIPTION
- Swift のバージョンを最新にアップデートします
  - これは、最新の swiftlint が v3.1 以上を要求するためです。
- デフォルトのロケールを UTF-8 にします。